### PR TITLE
expose location and offset in RegistryEntry

### DIFF
--- a/vach/src/global/reg_entry.rs
+++ b/vach/src/global/reg_entry.rs
@@ -18,7 +18,7 @@ pub struct RegistryEntry {
 	pub signature: Option<esdalek::Signature>,
 	/// The location of the file in the archive, as bytes from the beginning of the file
 	pub location: u64,
-	/// The size of the file
+	/// The size of the file, in the archive. This does not always correspond to the actual size of the file when read from the archive!
 	pub offset: u64,
 }
 


### PR DESCRIPTION
This could be useful when the program wants to know the size of the file in the archive (vach-cli also needs this)