### PR TITLE
Use log in vach-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,12 +423,25 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -495,6 +508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
 ]
 
 [[package]]
@@ -757,6 +779,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +796,12 @@ checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1152,7 +1190,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "assets_manager",
- "env_logger",
+ "env_logger 0.9.0",
  "log",
  "parking_lot",
  "pathdiff",
@@ -1176,6 +1214,7 @@ dependencies = [
  "clap 3.0.14",
  "indicatif",
  "log",
+ "pretty_env_logger",
  "tabled",
  "vach 0.3.4",
  "walkdir",

--- a/vach-cli/Cargo.toml
+++ b/vach-cli/Cargo.toml
@@ -26,3 +26,4 @@ tabled = "0.4.0"
 log = "0.4.14"
 vach = { path = "../vach", features = ["multithreaded"], version = "^0.3.3" }
 walkdir = "2.3.2"
+pretty_env_logger = "0.4.0"

--- a/vach-cli/src/commands/pack.rs
+++ b/vach-cli/src/commands/pack.rs
@@ -63,7 +63,7 @@ impl CommandTrait for Evaluator {
 					match path.canonicalize() {
 						Ok(path) => Some(path),
 						Err(err) => {
-							println!(
+							log::warn!(
 								"Failed to evaluate: {}. Skipping due to error: {}",
 								path.to_string_lossy(),
 								err
@@ -84,7 +84,7 @@ impl CommandTrait for Evaluator {
 		let path_filter = |path: &PathBuf| match path.canonicalize() {
 			Ok(canonical) => !excludes.contains(&canonical) && canonical.is_file(),
 			Err(err) => {
-				println!(
+				log::warn!(
 					"Failed to evaluate: {}. Skipping due to error: {}",
 					path.to_string_lossy(),
 					err
@@ -126,7 +126,7 @@ impl CommandTrait for Evaluator {
 		if let Some(path) = args.value_of(key_names::SOURCE) {
 			// Storing the path of the archive for reporting purposes
 			archive_path = path;
-			dbg!(archive_path);
+			log::trace!(format!("{}", archive_path));
 
 			let archive_file = File::open(PathBuf::from(path))?;
 			archive = Some(Archive::from_handle(archive_file)?);
@@ -180,7 +180,7 @@ impl CommandTrait for Evaluator {
 
 			let mut file = File::create("keypair.kp")?;
 			file.write_all(&generated.to_bytes())?;
-			println!("Generated a new keypair @ keypair.kp");
+			log::info!("Generated a new keypair @ keypair.kp");
 
 			kp = Some(generated);
 		}

--- a/vach-cli/src/commands/unpack.rs
+++ b/vach-cli/src/commands/unpack.rs
@@ -84,7 +84,7 @@ impl CommandTrait for Evaluator {
 
 		// Delete original archive
 		if truncate {
-			println!("Truncating original archive @ {}", &input_path);
+			log::info!("Truncating original archive @ {}", &input_path);
 			std::fs::remove_file(input_path)?;
 		};
 

--- a/vach-cli/src/main.rs
+++ b/vach-cli/src/main.rs
@@ -6,6 +6,7 @@ mod utils;
 
 // NOTE: Unwrapping in a CLI is a no-no. Since throwing Rust developer errors at average users is mental overload
 fn main() {
+	pretty_env_logger::init();
 	use keys::key_names;
 
 	// Build CLI
@@ -29,6 +30,6 @@ fn main() {
 	};
 
 	if let Err(err) = res {
-		println!("[VACH-CLI ERROR]: {}", err)
+		log::error!("{}", err)
 	};
 }


### PR DESCRIPTION
This replaces (most) `println!`'s with log calls on appropriate levels and initializes `pretty_env_logger` in the cli.

solves #47 