### PR TITLE
Fix for `Archive::fetch_write(---)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +335,16 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1177,6 +1201,7 @@ version = "0.3.4"
 dependencies = [
  "aes-gcm",
  "brotli",
+ "crossbeam",
  "ed25519-dalek",
  "lz4_flex",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,20 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,16 +321,6 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd435b205a4842da59efd07628f921c096bc1cc0a156835b4fa0bcb9a19bcce"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1201,7 +1177,7 @@ version = "0.3.4"
 dependencies = [
  "aes-gcm",
  "brotli",
- "crossbeam",
+ "crossbeam-channel",
  "ed25519-dalek",
  "lz4_flex",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -594,9 +594,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "lock_api"
@@ -942,9 +942,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "serde"

--- a/vach-cli/src/commands/pack.rs
+++ b/vach-cli/src/commands/pack.rs
@@ -126,7 +126,7 @@ impl CommandTrait for Evaluator {
 		if let Some(path) = args.value_of(key_names::SOURCE) {
 			// Storing the path of the archive for reporting purposes
 			archive_path = path;
-			log::trace!(format!("{}", archive_path));
+			log::trace!("{}", format!("{}", archive_path));
 
 			let archive_file = File::open(PathBuf::from(path))?;
 			archive = Some(Archive::from_handle(archive_file)?);

--- a/vach/Cargo.toml
+++ b/vach/Cargo.toml
@@ -28,7 +28,7 @@ brotli = "3.3.2"
 
 # Multithreaded feature
 rayon = { version = "1.5.1", optional = true }
-crossbeam = { version = "0.8.1", optional = true }
+crossbeam-channel = { version = "0.5.2", optional = true }
 
 [features]
-multithreaded = ["rayon", "crossbeam"]
+multithreaded = ["rayon", "crossbeam-channel"]

--- a/vach/Cargo.toml
+++ b/vach/Cargo.toml
@@ -25,7 +25,10 @@ rand = "0.7.0"
 aes-gcm = { version = "0.9.4", features = ["aes"] }
 snap = "1.0.5"
 brotli = "3.3.2"
+
+# Multithreaded feature
 rayon = { version = "1.5.1", optional = true }
+crossbeam = { version = "0.8.1", optional = true }
 
 [features]
-multithreaded = ["rayon"]
+multithreaded = ["rayon", "crossbeam"]

--- a/vach/src/loader/archive.rs
+++ b/vach/src/loader/archive.rs
@@ -331,8 +331,10 @@ impl<T: Read + Seek + Send + Sync> Archive<T> {
 		&mut self, items: I,
 	) -> InternalResult<HashMap<String, InternalResult<Resource>>> {
 		use rayon::prelude::*;
+		use crossbeam::channel;
+
 		let mut processed = HashMap::new();
-		let (sender, receiver) = std::sync::mpsc::sync_channel(20);
+		let (sender, receiver) = channel::unbounded();
 
 		items.par_bridge().try_for_each(|id| -> InternalResult<()> {
 			let id = id.into();

--- a/vach/src/loader/archive.rs
+++ b/vach/src/loader/archive.rs
@@ -317,7 +317,7 @@ where
 impl<T: Read + Seek + Send + Sync> Archive<T> {
 	/// Retrieves several resources in parallel. This is much faster than calling `Archive::fetch(---)` in a loop as it utilizes abstracted functionality.
 	/// This function is only available with the `multithreaded` feature. Use `Archive::fetch(---)` | `Archive::fetch_write(---)` in your own loop construct otherwise
-	pub fn fetch_batch<'a, I: Iterator<Item = &'a str> + Send + Sync>(
+	pub fn fetch_batch<'a, I: Iterator<Item = S> + Send + Sync, S: Send + Sync + Into<&'a str>>(
 		&mut self, items: I,
 	) -> InternalResult<HashMap<String, InternalResult<Resource>>> {
 		use rayon::prelude::*;
@@ -325,6 +325,7 @@ impl<T: Read + Seek + Send + Sync> Archive<T> {
 		let (sender, receiver) = std::sync::mpsc::sync_channel(20);
 
 		items.par_bridge().try_for_each(|id| -> InternalResult<()> {
+			let id = id.into();
 			let resource = self.fetch(id);
 			let id = id.to_string();
 

--- a/vach/src/loader/archive.rs
+++ b/vach/src/loader/archive.rs
@@ -25,13 +25,23 @@ use ed25519_dalek as esdalek;
 /// It can be customized with the `HeaderConfig` struct.
 /// > **A word of advice:**
 /// > Does not buffer the underlying handle, so consider wrapping `handle` in a `BufReader`
-#[derive(Debug)]
 pub struct Archive<T> {
 	header: Header,
 	handle: Arc<Mutex<T>>,
 	decryptor: Option<Encryptor>,
 	key: Option<esdalek::PublicKey>,
 	entries: HashMap<String, RegistryEntry>,
+}
+
+impl<T> std::fmt::Debug for Archive<T> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Archive")
+			.field("header", &self.header)
+			.field("decryptor", &self.decryptor)
+			.field("key", &self.key)
+			.field("entries", &self.entries)
+			.finish()
+	}
 }
 
 impl<T> Archive<T> {

--- a/vach/src/loader/archive.rs
+++ b/vach/src/loader/archive.rs
@@ -331,10 +331,9 @@ impl<T: Read + Seek + Send + Sync> Archive<T> {
 		&mut self, items: I,
 	) -> InternalResult<HashMap<String, InternalResult<Resource>>> {
 		use rayon::prelude::*;
-		use crossbeam::channel;
 
 		let mut processed = HashMap::new();
-		let (sender, receiver) = channel::unbounded();
+		let (sender, receiver) = crossbeam_channel::unbounded();
 
 		items.par_bridge().try_for_each(|id| -> InternalResult<()> {
 			let id = id.into();

--- a/vach/src/utils/mod.rs
+++ b/vach/src/utils/mod.rs
@@ -16,6 +16,7 @@ pub fn gen_keypair() -> esdalek::Keypair {
 pub fn read_keypair<R: Read>(mut handle: R) -> InternalResult<esdalek::Keypair> {
 	let mut keypair_bytes = [0; crate::KEYPAIR_LENGTH];
 	handle.read_exact(&mut keypair_bytes)?;
+
 	Ok(match esdalek::Keypair::from_bytes(&keypair_bytes) {
 		Ok(kep) => kep,
 		Err(err) => return Err(InternalError::ParseError(err.to_string())),


### PR DESCRIPTION
Prevents execution from locking up when a user attempts to fetch more than 20 items concurrently. Thx to `crossbeam-channel`